### PR TITLE
Clean up the mission selection logic and fix the teleop mission runner

### DIFF
--- a/src/com/teamcautionrobotics/autonomous2018/MissionSelector.java
+++ b/src/com/teamcautionrobotics/autonomous2018/MissionSelector.java
@@ -1,5 +1,6 @@
 package com.teamcautionrobotics.autonomous2018;
 
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -156,6 +157,38 @@ public class MissionSelector {
 
         autoCommands.addAll(Arrays.asList(commands));
         return new Mission(name, autoCommands);
+    }
+
+    public Mission selectMissionFromFmsString(StartingPosition startingPosition,
+            AutoObjective objective, String fmsData) throws ParseException {
+
+        PlateSide switchPosition;
+        PlateSide scalePosition;
+
+        if (fmsData.length() == 3) {
+            if (fmsData.charAt(0) == 'L') {
+                switchPosition = PlateSide.LEFT;
+            } else if (fmsData.charAt(0) == 'R') {
+                switchPosition = PlateSide.RIGHT;
+            } else {
+                throw new ParseException(String.format(
+                        "expected [LR] for FMS switch char, got %c instead", fmsData.charAt(0)), 0);
+            }
+
+            if (fmsData.charAt(1) == 'L') {
+                scalePosition = PlateSide.LEFT;
+            } else if (fmsData.charAt(1) == 'R') {
+                scalePosition = PlateSide.RIGHT;
+            } else {
+                throw new ParseException(String.format(
+                        "expected [LR] for FMS scale char, got %c instead", fmsData.charAt(0)), 3);
+            }
+        } else {
+            throw new ParseException(String.format(
+                    "expected 3 char string for FMS data, got '%s' instead", fmsData), 0);
+        }
+
+        return selectMissionFromFieldData(switchPosition, scalePosition, startingPosition, objective);
     }
 
     public Mission selectMissionFromFieldData(PlateSide switchSide, PlateSide scaleSide,

--- a/src/com/teamcautionrobotics/robot2018/Robot.java
+++ b/src/com/teamcautionrobotics/robot2018/Robot.java
@@ -141,8 +141,7 @@ public class Robot extends TimedRobot {
         addObjectsToChooser(autoModeChooser, AutoMode.FMS_DATA, AutoMode.values());
         SmartDashboard.putData("Autonomous Mode Select", autoModeChooser);
 
-        // TODO(Schuyler): fix the missionSendable
-        missionSendable = new MissionSendable("Teleop Mission", () -> missionScriptMission);
+        missionSendable = new MissionSendable("Teleop Mission", this::selectMission);
         SmartDashboard.putData(missionSendable);
 
 
@@ -182,7 +181,7 @@ public class Robot extends TimedRobot {
         // TODO(Schuyler): fix this
         // SmartDashboard.putString("selected mission", autoModeChooser.getSelected().getName());
 
-        if ((missionSendable.run() /* && !autoModeChooser.getSelected().enableControls */)
+        if ((missionSendable.run() && !selectMission().enableControls)
                 || driveBase.pidController.isEnabled()) {
             return;
         }


### PR DESCRIPTION
This moves logic for selecting the autonomous mission based on the starting position, objective, and mode and for parsing the FMS data to be in their own functions. It also makes the "Teleop Mission" missionSendable select the mission to run using the same logic as autonomous uses, instead of just running the MissionScript mission.